### PR TITLE
Double Value Support

### DIFF
--- a/Graphite/GraphiteTcpClient.cs
+++ b/Graphite/GraphiteTcpClient.cs
@@ -20,7 +20,7 @@ namespace Graphite
             _tcpClient = new TcpClient(Hostname, Port);
         }
 
-        public void Send(string path, int value, DateTime timeStamp)
+        public void Send(string path, double value, DateTime timeStamp)
         {
             try
             {

--- a/Graphite/GraphiteUdpClient.cs
+++ b/Graphite/GraphiteUdpClient.cs
@@ -20,7 +20,7 @@ namespace Graphite
             _udpClient = new UdpClient(Hostname, Port);
         }
 
-        public void Send(string path, int value, DateTime timeStamp)
+        public void Send(string path, double value, DateTime timeStamp)
         {
             try
             {

--- a/Graphite/IGraphiteClient.cs
+++ b/Graphite/IGraphiteClient.cs
@@ -4,7 +4,7 @@ namespace Graphite
 {
     public interface IGraphiteClient
     {
-        void Send(string path, int value, DateTime timeStamp);
+        void Send(string path, double value, DateTime timeStamp);
     }
 
     public static class IGraphiteClientExtensions

--- a/Graphite/PlaintextMessage.cs
+++ b/Graphite/PlaintextMessage.cs
@@ -6,10 +6,10 @@ namespace Graphite
     public class PlaintextMessage
     {
         public string Path { get; private set; }
-        public int Value { get; private set; }
+        public double Value { get; private set; }
         public long Timestamp { get; private set; }
 
-        public PlaintextMessage(string path, int value, DateTime timestamp)
+        public PlaintextMessage(string path, double value, DateTime timestamp)
         {
             if(path == null)
             {
@@ -23,7 +23,7 @@ namespace Graphite
 
         public byte[] ToByteArray()
         {
-            var line = string.Format("{0} {1} {2}\n", Path, Value, Timestamp);
+            var line = string.Format("{0} {1} {2}\n", Path, Convert.ToString(Value).Replace(",","."), Timestamp);
 
             return Encoding.UTF8.GetBytes(line);
         }


### PR DESCRIPTION
Graphite API supports int and double values as input. 
The changes are necessary that this implementation does also support double values and are able to send them to Graphite.

Support for "," and "." as decimal delimiter is a little bit dirty.... 